### PR TITLE
Add initial README and rust guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Mullvad coding guidelines
+
+These documents aim to be the source of information for how we architect, design and format
+program code in various languages and tools.
+
+[Rust](rust.md)

--- a/rust.md
+++ b/rust.md
@@ -30,12 +30,25 @@ macros.
 ### Generic Rust type improvement tips
 
 * Avoid unnecessary conversions that introduce either extra possible error states or loss of data/
-  precision if possible. A common example being `OsString -> String -> Path`. `Path` is based on
-  `OsString` and converting `OsString -> Path` is both free and infallible. While
-  `OsString -> String` must be done either as a lossy conversion or with the possibility of getting
-  an error if the data is not correct UTF-8.
+  precision if possible.
+  ```rust
+  // DONT: Will return an error if the content is not correct UTF-8.
+  let path = env::var("A_PATH_VARIABLE").map(PathBuf::from);
+
+  // DO: Does not enforce any encoding on the path.
+  let path = env::var_os("A_PATH_VARIABLE").map(PathBuf::from);
+  ```
 * The appropriate borrowed versions of `Vec<T>`, `String` and `PathBuf` are `&[T]`, `&str` and
   `&Path`. Not `&Vec<T>`, `&String` and `&PathBuf`.
+  ```rust
+  // DONT
+  fn sum(data: &Vec<u32>) -> u32 { ... }
+  fn read_file(path: &PathBuf) -> Vec<u8> { ... }
+
+  // DO
+  fn sum(data: &[u32]) -> u32 { ... }
+  fn read_file(path: &Path) -> Vec<u8> { ... }
+  ```
 
 
 [rustfmt configuration]: https://github.com/mullvad/mullvadvpn-app/blob/master/rustfmt.toml

--- a/rust.md
+++ b/rust.md
@@ -1,0 +1,42 @@
+# Rust coding guidelines
+
+## Formatting
+
+All code should be formatted with the latest release of rustfmt. The [rustfmt configuration] in the
+mullvadvpn-app repository is the reference configuration, in order to not have to repeat it here.
+
+Also see the [EditorConfig settings] for further file format standards to follow.
+
+## Code/API design
+
+Follow the standard [Rust API guidelines] as much as possible.
+
+Run clippy on all code and follow the recommendations it prints in all places where it is reasonable
+to follow.
+
+There is an [unofficial guide to design patterns in Rust] that it can be worth looking at.
+
+There is an [unofficial book about Rust macro design] that can provide good design patterns for
+macros.
+
+### Other/custom design guidelines
+
+* Crate names should be kebab-case
+* Don't have debug formatted (`{:?}`) strings in messages shown to a user, except in `debug!` and
+  `trace!` log entries if needed
+* When converting a path to a string intended for user viewing, use `Path::display()`
+* Desired argument order for assertions is `assert_eq!(actual, expected)`
+
+### Generic Rust type improvement tips
+
+* If a piece of data (eg. argument) can be obtained as an `OsStr` and will in the end be used as
+  such as well (like a `Path`), try to not go through making it a `str` and imposing UTF-8
+  restrictions unnecessarily
+* If you ever see an argument of type `&Vec<...>` you probably want `&[...]`
+* If you ever see an argument of type `&String` you probably want `&str`
+
+[rustfmt configuration]: https://github.com/mullvad/mullvadvpn-app/blob/master/rustfmt.toml
+[EditorConfig settings]: https://github.com/mullvad/mullvadvpn-app/blob/master/.editorconfig
+[Rust API guidelines]: https://rust-lang-nursery.github.io/api-guidelines/
+[unofficial guide to design patterns in Rust]: https://github.com/rust-unofficial/patterns
+[unofficial book about Rust macro design]: https://danielkeep.github.io/tlborm/book/

--- a/rust.md
+++ b/rust.md
@@ -29,11 +29,14 @@ macros.
 
 ### Generic Rust type improvement tips
 
-* If a piece of data (eg. argument) can be obtained as an `OsStr` and will in the end be used as
-  such as well (like a `Path`), try to not go through making it a `str` and imposing UTF-8
-  restrictions unnecessarily
-* If you ever see an argument of type `&Vec<...>` you probably want `&[...]`
-* If you ever see an argument of type `&String` you probably want `&str`
+* Avoid unnecessary conversions that introduce either extra possible error states or loss of data/
+  precision if possible. A common example being `OsString -> String -> Path`. `Path` is based on
+  `OsString` and converting `OsString -> Path` is both free and infallible. While
+  `OsString -> String` must be done either as a lossy conversion or with the possibility of getting
+  an error if the data is not correct UTF-8.
+* The appropriate borrowed versions of `Vec<T>`, `String` and `PathBuf` are `&[T]`, `&str` and
+  `&Path`. Not `&Vec<T>`, `&String` and `&PathBuf`.
+
 
 [rustfmt configuration]: https://github.com/mullvad/mullvadvpn-app/blob/master/rustfmt.toml
 [EditorConfig settings]: https://github.com/mullvad/mullvadvpn-app/blob/master/.editorconfig


### PR DESCRIPTION
Adding initial Rust coding guidelines. Copy pasted from the Confluence document we had.

This is to get an initial feel for this repository. If we think this approach and setup is good we can continue with more languages as needed.

I didn't receive any direct feedback on the actual content from Confluence as well. So feel free to debate the actual guideline content of course! If there is one place we should debate design and style it's here, in order to be able to reduce it elsewhere :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/1)
<!-- Reviewable:end -->
