### PR TITLE
Add generic file format instructions to main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,24 @@
 These documents aim to be the source of information for how we architect, design and format
 program code in various languages and tools.
 
-[Rust](rust.md)
+## Formatting
+
+See the [EditorConfig settings] in the main Mullvad VPN app repo for file format standards to
+follow.
+
+In general this is what to follow:
+
+* File encoding should be UTF-8 and not start with [BOM] bytes.
+* Files should end with newlines.
+* Don't have trailing spaces on any lines.
+* Indent only with spaces. Except for languages where it is customary to use tabs.
+* Only commit LF (`\n`) line endings to git. If you configure git to convert to and from CRLF
+  (`\r\n`) in the working directory that is fine, but only commit LF line endings.
+
+## Language specific guidelines
+
+* [Rust](rust.md)
+
+
+[EditorConfig settings]: https://github.com/mullvad/mullvadvpn-app/blob/master/.editorconfig
+[BOM]: https://en.wikipedia.org/wiki/Byte_order_mark

--- a/rust.md
+++ b/rust.md
@@ -5,7 +5,7 @@
 All code should be formatted with the latest release of rustfmt. The [rustfmt configuration] in the
 mullvadvpn-app repository is the reference configuration, in order to not have to repeat it here.
 
-Also see the [EditorConfig settings] for further file format standards to follow.
+Also see the [main page] for general file format standards to follow.
 
 ## Code/API design
 
@@ -52,7 +52,7 @@ macros.
 
 
 [rustfmt configuration]: https://github.com/mullvad/mullvadvpn-app/blob/master/rustfmt.toml
-[EditorConfig settings]: https://github.com/mullvad/mullvadvpn-app/blob/master/.editorconfig
+[main page]: ./README.md
 [Rust API guidelines]: https://rust-lang-nursery.github.io/api-guidelines/
 [unofficial guide to design patterns in Rust]: https://github.com/rust-unofficial/patterns
 [unofficial book about Rust macro design]: https://danielkeep.github.io/tlborm/book/


### PR DESCRIPTION
I'm sorry if you think it becomes noisy to review all of these. But the plan is that everyone should have a say when this is created. So hopefully we don't have to change these document very much at all the future, except for adding tips and rules as we reach consensus on more things to follow.

Reason why it's good if we can agree up front and then not having to change them is because a change in these documents likely lead to having to change a lot of code as well. And there will of course be times when that is needed or wanted for various reasons. But the more we can agree up front, the less of those instances we are likely to have I think.

Please remind me if I forgot any small rule we have talked about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/2)
<!-- Reviewable:end -->
