### PR TITLE
Add section on bash script filenames

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -6,6 +6,11 @@ nice code.
 
 [`shellcheck`]: https://www.shellcheck.net/
 
+## Filename
+
+Bash script files should follow the `kebab-case.sh` style convention unless special circumstances
+mandates something else.
+
 ## Shebang
 
 Start a Bash script with the following to make it parse consistently.


### PR DESCRIPTION
We have previously discussed bash script filename standards in other places where we created new scripts. We found out that we most commonly use `kebab-case` naming rather than `snake_case`. It also seems fairly standard outside of Mullvad as well so we went with that for new scripts. This PR finally makes that into a guideline so it's well defined and not forgotten.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/6)
<!-- Reviewable:end -->
