### PR TITLE
Add cargo dependency section

### DIFF
--- a/rust.md
+++ b/rust.md
@@ -148,6 +148,21 @@ unsafe {
 
 ## Cargo dependencies
 
+### Specifying version numbers
+
+When adding a new dependency, prefer specifying the full version number of the latest release.
+If adding `regex` and the latest release is `1.5.6` specify `regex = "1.5.6"`. In general,
+avoid adding just `"1"` or `"1.5"`. This is because Cargo will automatically pull in the latest
+version allowed by your version specification. Meaning it will pull in `1.5.6` even if you specify
+`1`. Then you can accidentally write code that needs `regex` `>1.x` where `x` is greater than `0`.
+
+If you specify a version requirement looser than the exact latest version anyway, you need to
+make sure the code you write compiles on the oldest version of that crate allowed by the
+version specification. This can be done with the following command:
+```
+cargo +nightly update -Z minimal-versions && cargo check
+```
+
 ### Git dependencies
 
 In general, prefer crates released on crates.io over depending on git repositories in `Cargo.toml`.

--- a/rust.md
+++ b/rust.md
@@ -146,6 +146,23 @@ unsafe {
 }
 ```
 
+## Cargo dependencies
+
+### Git dependencies
+
+In general, prefer crates released on crates.io over depending on git repositories in `Cargo.toml`.
+Git repositories are not as persistant over time and not guaranteed to always be online etc.
+But there are exceptions. You might need to depend on a git repository dependency for unpublished
+crates and similar. If depending on a git repository always do the following:
+
+* If it's someone else's repository, fork it into our own organization/account. This is to take
+  more control over the availability. This prevents the repository from suddenly being gone.
+* Always specify the commit hash to depend on, never just a branch or similar. Branches can move
+  and then the dependency is changing under our feet without us changing anything. In `Cargo.toml`
+  specify `rev = ...` and never `branch = ...`.
+
+
+<!-- # Links -->
 
 [rustfmt configuration]: https://github.com/mullvad/mullvadvpn-app/blob/master/rustfmt.toml
 [main page]: ./README.md


### PR DESCRIPTION
Additions to the coding guidelines that makes it more clear how to work with dependencies. Some of these things are stuff we have done for a long time, but never written down. The rest is stuff I think is best practice, but should be agreed upon and in text so it can be referenced and not just spread word of mouth.

The first paragraph, about specifying the full version number. That's what `cargo add` already does, for this exact reason as far as I know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/15)
<!-- Reviewable:end -->
