### PR TITLE
Bash constants readonly

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -58,8 +58,7 @@ prefer to make the argument mandatory and pass `.` instead.
 * Constant variables use `SCREAMING_SNAKE_CASE` names.
 
   This means variables that are assigned once and then never modified, and that only depend on
-  other constant variables. The exception to "never modified" is where multiple statements are
-  used to compute the content of the "constant" (see `COMPILE_FLAGS` in example at the end).
+  other constant variables.
 
 * Non-constant variables use `snake_case` names.
 
@@ -69,6 +68,10 @@ prefer to make the argument mandatory and pass `.` instead.
 
 Environment variables and arguments to the script are considered constants. But arguments in
 functions are not constants.
+
+Constant variables should always have `readonly` applied to them. Non-constant variables can
+also have `readonly` applied to them assuming they are never modified and using `readonly` is
+not too verbose.
 
 ## Conditions and branching
 

--- a/bash.md
+++ b/bash.md
@@ -216,10 +216,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
 # Base compile flags valid all the time
-COMPILE_FLAGS="disable-foo enable-bar"
+compile_flags="disable-foo enable-bar"
 # Platform specific compile flags
 if [[ "$(uname -s)" != "Darwin" ]]; then
-    COMPILE_FLAGS+=" disable-apple"
+    compile_flags+=" disable-apple"
 fi
 
 # Script arguments count as constants


### PR DESCRIPTION
In bash guidelines add that constants should be `readonly` always and that non-constants that are not modified after declaration should be `readonly` on a best-effort basis.
Remove the part of the guideline that says that `COMPILER_FLAGS` is an example of a constant that can be modified after declaration. After discussion this was concluded not to be the case and that this variable should not be screaming snake case.
Update example to reflect this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/18)
<!-- Reviewable:end -->
