### PR TITLE
Clarify git commit message format and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ So sum it up the most important parts are:
 
 * Capitalize the subject line.
 * Do not end the subject line with a period.
-* Use the imperative mood in the subject line.
+* Use the imperative mood in the subject line, starting with a verb.
 
 ### History
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ variable name.
 
 ### Commit messages
 
-Here is a generally nice guide to how to write good commit messages:
+Here is a nice guide on how to write good commit messages:
 https://chris.beams.io/posts/git-commit/
 
 So sum it up the most important parts are:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ So sum it up the most important parts are:
 * Capitalize the subject line.
 * Do not end the subject line with a period.
 * Use the imperative mood in the subject line, starting with a verb.
+* Limit the subject line to 72 characters*
+* Separate the subject from the body with two regular newlines ('\n')
+
+\* The only exceptions to this length limit are merge and revert commits. They should have the
+commit message git inserts by default (`Merge branch '<name_of_branch>'` and
+`Revert "<subject_of_reverted_commit"`) even if the total length exceeds the guideline.
 
 ### History
 


### PR DESCRIPTION
@dlon pointed out that neither we, nor the guide we link to, explicitly states that a commit message should start with a verb (only that it should be in imperative mood). Yet we recently merged a CI job that enforces that the first word is a verb.  So I here update the guideline to explicitly state this, to match with expectations and current CI behavior.

While at it I took the time to write down some other rules that we currently enforce but don't mention. The subject line length limit we use is different than the one recommended in the blog post we link to, so it's definitely worth mentioning.

I don't expect this PR to be controversial. We already do this, we have just not written it down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/21)
<!-- Reviewable:end -->
