### PR TITLE
Add guidelines on git branch naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ So sum it up the most important parts are:
 commit message git inserts by default (`Merge branch '<name_of_branch>'` and
 `Revert "<subject_of_reverted_commit"`) even if the total length exceeds the guideline.
 
+### Branch naming
+
+Use kebab case git branch names with lowercase letters. For example `add-links-to-readme`.
+
+An exception to the style is if a part in the branch name requires a specific way of writing to
+not lose its meaning/technical context. Examples include:
+
+* `suppress-CVE-2026-3872` - "CVE-2026-3872" is a unique identifier. Changing it could change its
+  meaning and/or make it less recognizable.
+* `fix-multicast-address-translation-IOS-123` - "IOS-123" being a hypothetical ticketing system
+  identifier requiring a specific format for the automation to work.
+
+Try to avoid adding exact programming terms that do not need to be in the title, without
+reducing the information in the name too much. Instead of `implement-Clone-for-IpAddr` prefer
+`make-ip-address-type-clonable`.
+
+Try to describe what is being done in the branch, without being too verbose. High signal to noise
+ratio is important. Some examples:
+* Instead of `improve-readme` use `add-build-instructions`
+* Instead of `fix-routing-table` use `fix-linux-lan-route-parsing`
+
+There is no exact length limit on branch names, but try to stay relatively short.
+
+Slashes in branch names are allowed if the team use them consistently and according to an agreed
+upon system. Examples could include `android/fix-icon-rotation` or `linux/feature/add-multihop`.
+
 ### History
 
 Prefer to let the history represent how the project evolves rather than exactly how the developer


### PR DESCRIPTION
Nothing too controversial here I hope. But instead of transferring this information word of mouth it might be much simpler to have it written in a single place. Reduce risk of misunderstanding, and acts as a single source of truth in disputes.

Most of this is what we already do. Some of them are descriptions and arguments I came up with, but that I think you will find reasonable.

Just because I say slashes are allowed, that does not mean I suggest we should introduce them ASAP. I just want the guideline to be clear that they are allowed if a team would like to explore that area (I know we use them to some extent already)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/22)
<!-- Reviewable:end -->
