### PR TITLE
Add Rust recommended lints and bootstrap CI template directory

### DIFF
--- a/rust.md
+++ b/rust.md
@@ -1,6 +1,7 @@
 # Rust coding guidelines
 
 This document is about best practices and rules when writing Rust code.
+
 For guidelines on publishing to crates.io, see: [crates.io](./crates-io.md).
 
 ## Formatting
@@ -10,12 +11,22 @@ mullvadvpn-app repository is the reference configuration, in order to not have t
 
 Also see the [main page] for general file format standards to follow.
 
+## Linting
+
+Use at least the lints listed in [rust/Cargo.toml](rust/Cargo.toml).
+
+## CI
+
+All repositories containing Rust should have a CI pipeline that makes sure no compilation errors,
+warnings or test failures are merged to the main branch. Furthermore it should check that the code
+is formatted correctly and a bunch more stuff.
+
+See [.github/workflows/](.github/workflows/) for more details on bare minimum CI requirements.
+Some of these jobs might need to be adapted to work on a specific project.
+
 ## Code/API design
 
 Follow the standard [Rust API guidelines] as much as possible.
-
-Run clippy on all code and follow the recommendations it prints in all places where it is reasonable
-to follow.
 
 There is an [unofficial guide to design patterns in Rust] that it can be worth looking at.
 

--- a/rust/.github/workflows/cargo-shear.yml
+++ b/rust/.github/workflows/cargo-shear.yml
@@ -1,0 +1,23 @@
+---
+name: Unused dependencies
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cargo-shear.yml
+      - "**/*.rs"
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  cargo-shear:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@cargo-shear
+
+      - name: Run cargo shear
+        run: cargo shear

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,29 @@
+
+
+# All Clippy and Rust lints we want to activate. These are set to warn to only cause warnings
+# while developing. But due to `--deny warnings` in CI, these will be forbidden to merge.
+# Replace section with `[workspace.lints.clippy]`/[workspace.lints.rust] if used in a workspace
+[lints.clippy]
+allow_attributes = "warn"
+as_ptr_cast_mut = "warn"
+as_underscore = "warn"
+borrow_as_ptr = "warn"
+implicit_clone = "warn"
+undocumented_unsafe_blocks = "warn"
+unicode_not_nfc = "warn"
+unused_async = "deny"
+wildcard_dependencies = "deny"
+
+[lints.rust]
+absolute_paths_not_starting_with_crate = "deny"
+# Easy to read style and opinionated best practices
+explicit_outlives_requirements = "warn"
+macro_use_extern_crate = "deny"
+missing_abi = "deny"
+# Security
+non_ascii_idents = "forbid"
+# Deny old style Rust
+rust_2018_idioms = { level = "deny", priority = -1 }
+single_use_lifetimes = "warn"
+unused_lifetimes = "warn"
+unused_macro_rules = "warn"


### PR DESCRIPTION
As discussed in the Rust forum: Set up sort of a template directory for configuration we want applied to all repositories containing Rust code. This starts that work by doing two things:

* Create a minimal `Cargo.toml` with the lints we want to use. More lints can be added or changed later, but this is verbatim what we use in the main app repo right now
* Create a github actions workflow dir and a single job for now. We should add more jobs here later, but I wanted to establish the existance of this directory before spending more work on adding a bunch of CI jobs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/26)
<!-- Reviewable:end -->
