### PR TITLE
Bootstrap kotlin coding guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ variable name.
 * [Rust](rust.md)
 * [Bash](bash.md)
 * [Kotlin](kotlin.md)
+* [Swift](swift.md)
 
 
 ## Git

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ variable name.
 
 * [Rust](rust.md)
 * [Bash](bash.md)
+* [Kotlin](kotlin.md)
 
 
 ## Git

--- a/kotlin.md
+++ b/kotlin.md
@@ -1,0 +1,28 @@
+# Kotlin coding guidelines
+
+These guidelines apply to all Kotlin code we write, regardless of target platform.
+Android-specific conventions do not belong in this document.
+
+## Coding guidelines
+
+We follow the official [Kotlin coding conventions].
+
+## Linting and formatting
+
+All code is formatted with [ktfmt] using `kotlinLangStyle` and the [editorconfig] in the
+[mullvadvpn-app repository] is a reference configuration. We'll typically use additional
+linters such as [detekt], but that can differ on a project basis.
+
+Also see the [main page] for general file format standards to follow.
+
+## CI
+
+All repositories containing Kotlin should have a CI pipeline that fails on compilation errors,
+formatter diffs, detekt findings, and test failures before code is merged to the main branch.
+
+[Kotlin coding conventions]: https://kotlinlang.org/docs/coding-conventions.html
+[ktfmt]: https://github.com/facebook/ktfmt
+[detekt]: https://detekt.dev/
+[mullvadvpn-app repository]: https://github.com/mullvad/mullvadvpn-app
+[editorconfig]: https://github.com/mullvad/mullvadvpn-app/blob/main/android/.editorconfig
+[main page]: ./README.md


### PR DESCRIPTION
This PR aims to boostrap a `kotlin.md` with our Kotlin coding guidelines, similar to what we have for rust, swift and bash.

Fixes: DROID-2590

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/coding-guidelines/28)
<!-- Reviewable:end -->
